### PR TITLE
Add GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: lint
+
+on:
+  push:
+    paths:
+      - '**/*.sh'
+  pull_request:
+    paths:
+      - '**/*.sh'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: |
+          shellcheck --version
+          shellcheck --severity=error $(git ls-files '*.sh')

--- a/alias/aliases.sh
+++ b/alias/aliases.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # aliases.sh
 
 alias python='python3'


### PR DESCRIPTION
## Summary
- create a GitHub Actions workflow to run ShellCheck on shell scripts
- add a missing shebang line to `alias/aliases.sh`

## Testing
- `shellcheck --severity=error $(git ls-files '*.sh')`

------
https://chatgpt.com/codex/tasks/task_e_6871965096ec833196e35bdcd717c2bb