### PR TITLE
test: add functional tests for the alias/install-menu logic bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ on:
       - 'tests/**'
 
 jobs:
-  syntax:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Run syntax tests
+      - name: Run lint and functional tests
         run: |
           make lint
           make test

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This project supports both Bash and Zsh shells:
 
 ## Development
 
-Run `make lint` to execute ShellCheck on all scripts and `make test` to run simple syntax tests.
+Run `make lint` to execute ShellCheck on all scripts and `make test` to run the test suite in `tests/` — syntax checks plus functional tests for `install.sh`'s script discovery and the alias/env-persistence scripts (run in a sandboxed `$HOME`, so nothing on your real machine is touched).
 
 ## Contributing
 

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ help:
 	@echo "  make ripgrep           - Install Ripgrep (fast text search)"
 	@echo "  make open_ssh_client   - Install OpenSSH Client"
 	@echo "  make lint              - Run ShellCheck on scripts"
-	@echo "  make test              - Run script syntax tests"
+	@echo "  make test              - Run the test suite (syntax + functional tests)"
 
 install:
 	@bash $(ROOT)/install.sh
@@ -79,4 +79,7 @@ lint:
 	@shellcheck --severity=error $(shell git ls-files '*.sh')
 
 test:
-	@./tests/test_syntax.sh
+	@for t in tests/test_*.sh; do \
+		echo "==> $$t"; \
+		bash "$$t" || exit 1; \
+	done

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,46 @@
+# Shared helpers for tests/test_*.sh functional tests.
+# Meant to be sourced, not executed directly.
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass() {
+  echo "✅ PASS: $1"
+}
+
+fail() {
+  echo "❌ FAIL: $1" >&2
+  exit 1
+}
+
+# Runs $2 (a script) with HOME=$1, as if launched from a genuine bash
+# login shell, so scripts that inspect the parent process
+# (ps -o comm= -p $PPID) see "bash" regardless of which shell is
+# actually driving this test run.
+run_as_bash() {
+  local home="$1" script="$2"
+  bash -c 'HOME="$1" SHELL=/bin/bash bash "$2"' _ "$home" "$script"
+}
+
+run_as_zsh() {
+  local home="$1" script="$2"
+  HOME="$home" SHELL=/bin/zsh bash "$script"
+}
+
+assert_file_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if [ ! -f "$file" ]; then
+    fail "$desc (file not found: $file)"
+  fi
+  if ! grep -qF -- "$pattern" "$file"; then
+    fail "$desc (expected to find '$pattern' in $file)"
+  fi
+  pass "$desc"
+}
+
+assert_file_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if [ -f "$file" ] && grep -qF -- "$pattern" "$file"; then
+    fail "$desc (did not expect to find '$pattern' in $file)"
+  fi
+  pass "$desc"
+}

--- a/tests/test_install_aliases.sh
+++ b/tests/test_install_aliases.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Functional tests for alias/install_aliases.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+echo "--- test_install_aliases.sh ---"
+
+SANDBOX="$(mktemp -d)"
+mkdir -p "$SANDBOX/home"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+if ! run_as_bash "$SANDBOX/home" "$REPO_DIR/alias/install_aliases.sh" \
+    < /dev/null > "$SANDBOX/run1.log" 2>&1; then
+  cat "$SANDBOX/run1.log"
+  fail "install_aliases.sh exited non-zero on first run"
+fi
+
+ALIASES_FILE="$SANDBOX/home/.bash_aliases"
+
+assert_file_contains "$ALIASES_FILE" "alias utils='bash $REPO_DIR/install.sh'" \
+  "resolves __PERSONAL_UTILS_DIR__ to the actual repo path"
+
+assert_file_not_contains "$ALIASES_FILE" "__PERSONAL_UTILS_DIR__" \
+  "does not leave the raw placeholder in the installed aliases"
+
+# Running it again should not duplicate any alias.
+if ! run_as_bash "$SANDBOX/home" "$REPO_DIR/alias/install_aliases.sh" \
+    < /dev/null > "$SANDBOX/run2.log" 2>&1; then
+  cat "$SANDBOX/run2.log"
+  fail "install_aliases.sh exited non-zero on second run"
+fi
+
+UTILS_COUNT=$(grep -c "^alias utils=" "$ALIASES_FILE")
+if [ "$UTILS_COUNT" -ne 1 ]; then
+  fail "running install_aliases.sh twice produced $UTILS_COUNT 'utils' aliases instead of 1"
+fi
+pass "running install_aliases.sh twice does not duplicate aliases"
+
+echo "All install_aliases.sh tests passed."

--- a/tests/test_install_menu.sh
+++ b/tests/test_install_menu.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Functional tests for install.sh's script discovery, plus static
+# regression guards for the airbyte.sh path fix and the pipefail fixes.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+echo "--- test_install_menu.sh ---"
+
+MENU_LOG="$(mktemp)"
+trap 'rm -f "$MENU_LOG"' EXIT
+
+# install.sh reads its selection from /dev/tty, which isn't available in
+# CI/sandboxes, so it's expected to exit non-zero after printing the menu.
+# We only care that script discovery itself behaved correctly.
+bash "$REPO_DIR/install.sh" < /dev/null > "$MENU_LOG" 2>&1 || true
+
+assert_file_not_contains "$MENU_LOG" "gcloud': No such file or directory" \
+  "install.sh no longer scans a nonexistent top-level gcloud/ dir"
+
+assert_file_contains "$MENU_LOG" "tools/gcloud.sh" \
+  "install.sh still discovers gcloud.sh from tools/"
+
+assert_file_contains "$MENU_LOG" "airbyte/airbyte.sh" \
+  "install.sh still discovers airbyte.sh"
+
+# --- static regression guards ---
+
+if grep -qF './docker.sh' "$REPO_DIR/airbyte/airbyte.sh"; then
+  fail "airbyte.sh still references docker.sh by a cwd-relative path"
+fi
+pass "airbyte.sh no longer references docker.sh by a cwd-relative path"
+
+DOCKER_SCRIPT="$REPO_DIR/tools/docker.sh"
+if [ ! -f "$DOCKER_SCRIPT" ]; then
+  fail "airbyte.sh's resolved docker.sh path ($DOCKER_SCRIPT) does not exist"
+fi
+pass "airbyte.sh's resolved docker.sh path exists"
+
+for f in tools/gcloud.sh tools/terraform.sh airbyte/airbyte.sh; do
+  if ! grep -q 'pipefail' "$REPO_DIR/$f"; then
+    fail "$f is missing 'pipefail' despite piping curl into another command"
+  fi
+  pass "$f enables pipefail"
+done
+
+echo "All install.sh menu tests passed."

--- a/tests/test_persist_env.sh
+++ b/tests/test_persist_env.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Functional tests for alias/code/persist_env.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+echo "--- test_persist_env.sh ---"
+
+PERSIST_ENV="$REPO_DIR/alias/code/persist_env.sh"
+
+# --- bash: variable should land in .bashrc, not .zshrc ---
+SANDBOX="$(mktemp -d)"
+mkdir -p "$SANDBOX/home"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+if ! run_as_bash "$SANDBOX/home" "$PERSIST_ENV" \
+    <<< $'MY_VAR\nhello' > "$SANDBOX/run.log" 2>&1; then
+  cat "$SANDBOX/run.log"
+  fail "persist_env.sh exited non-zero under bash"
+fi
+
+assert_file_contains "$SANDBOX/home/.bashrc" 'export MY_VAR="hello"' \
+  "bash: persists the variable to .bashrc"
+assert_file_not_contains "$SANDBOX/home/.zshrc" 'MY_VAR' \
+  "bash: does not touch .zshrc"
+
+rm -rf "$SANDBOX"
+
+# --- zsh: variable should land in .zshrc, not .bashrc ---
+SANDBOX="$(mktemp -d)"
+mkdir -p "$SANDBOX/home"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+if ! run_as_zsh "$SANDBOX/home" "$PERSIST_ENV" \
+    <<< $'MY_VAR\nhello' > "$SANDBOX/run.log" 2>&1; then
+  cat "$SANDBOX/run.log"
+  fail "persist_env.sh exited non-zero under zsh"
+fi
+
+assert_file_contains "$SANDBOX/home/.zshrc" 'export MY_VAR="hello"' \
+  "zsh: persists the variable to .zshrc"
+assert_file_not_contains "$SANDBOX/home/.bashrc" 'MY_VAR' \
+  "zsh: does not touch .bashrc"
+
+# --- declining the overwrite prompt leaves the existing value untouched ---
+if ! run_as_zsh "$SANDBOX/home" "$PERSIST_ENV" \
+    <<< $'MY_VAR\nworld\nn' > "$SANDBOX/run2.log" 2>&1; then
+  cat "$SANDBOX/run2.log"
+  fail "persist_env.sh exited non-zero when declining an overwrite"
+fi
+
+assert_file_contains "$SANDBOX/home/.zshrc" 'export MY_VAR="hello"' \
+  "zsh: declining overwrite keeps the original value"
+assert_file_not_contains "$SANDBOX/home/.zshrc" 'export MY_VAR="world"' \
+  "zsh: declining overwrite does not write the new value"
+
+echo "All persist_env.sh tests passed."


### PR DESCRIPTION
## Summary
Adds sandboxed functional tests (tests/lib.sh + tests/test_*.sh) covering the
bugs fixed in #<PR1_NUMBER>: alias path placeholder resolution, per-shell rc
file selection in persist_env.sh, and install.sh's menu discovery. Stacked on
top of fix/installer-path-bugs since these tests assert the fixed behavior.

## Test plan
- [x] make lint / make test pass locally