### PR TITLE
fix: silence shellcheck SC2148 on tests/lib.sh

### DIFF
--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared helpers for tests/test_*.sh functional tests.
 # Meant to be sourced, not executed directly.
 


### PR DESCRIPTION
## Summary
CI broke after #12 merged: `make lint` fails with SC2148 on `tests/lib.sh` because it's meant to be sourced (not executed directly) and intentionally has no shebang. This passed locally before commit only because `make lint` scopes to `git ls-files '*.sh'`, which skips untracked files — the check was accidentally never run against the tracked version of this file until it landed on master.

Fix: add the `# shellcheck shell=bash` directive shellcheck recommends for sourced-only scripts.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (all functional tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)