### PR TITLE
feat: add pyenv as an installable tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The main entry point is `install.sh`, which scans these folders and presents an 
 - **Git** - Version control system
 - **Terraform** - Infrastructure as Code
 - **Google Cloud CLI** - Google Cloud Platform tools
+- **pyenv** - Manage and switch between multiple Python versions
 
 ### 🎨 Modern Terminal Tools
 - **Eza** - Modern replacement for `ls` with icons and colors
@@ -68,7 +69,7 @@ You can install specific tools using make commands:
 
 ```bash
 # Development tools
-make docker git terraform
+make docker git terraform pyenv
 
 # Modern terminal tools
 make eza batcat ripgrep
@@ -102,8 +103,9 @@ make sublime           # Install Sublime Text
 make cursor            # Install Cursor (Snap installation)
 make ripgrep           # Install Ripgrep (fast text search)
 make open_ssh_client   # Install OpenSSH Client
+make pyenv             # Install pyenv (Python version manager)
 make lint              # Run ShellCheck on scripts
-make test              # Run script syntax tests
+make test              # Run the test suite (syntax + functional tests)
 make help              # Show all available commands
 ```
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: install aliases docker gcloud gedit git terraform airbyte eza batcat zsh oh-my-zsh zsh-customization sublime cursor ripgrep open_ssh_client help lint test
+.PHONY: install aliases docker gcloud gedit git terraform airbyte eza batcat zsh oh-my-zsh zsh-customization sublime cursor ripgrep open_ssh_client pyenv help lint test
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -21,6 +21,7 @@ help:
 	@echo "  make cursor            - Install Cursor (Snap installation)"
 	@echo "  make ripgrep           - Install Ripgrep (fast text search)"
 	@echo "  make open_ssh_client   - Install OpenSSH Client"
+	@echo "  make pyenv             - Install pyenv (Python version manager)"
 	@echo "  make lint              - Run ShellCheck on scripts"
 	@echo "  make test              - Run the test suite (syntax + functional tests)"
 
@@ -74,6 +75,9 @@ ripgrep:
 
 open_ssh_client:
 	@bash $(ROOT)/tools/open_ssh_client.sh
+
+pyenv:
+	@bash $(ROOT)/tools/pyenv.sh
 
 lint:
 	@shellcheck --severity=error $(shell git ls-files '*.sh')

--- a/tools/pyenv.sh
+++ b/tools/pyenv.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "🐍 Installing pyenv..."
+
+if command -v pyenv &> /dev/null || [ -d "$HOME/.pyenv" ]; then
+  echo "✅ pyenv is already installed."
+  echo "🔧 Location: $HOME/.pyenv"
+else
+  echo "📦 Installing pyenv build dependencies..."
+  sudo apt-get update -y
+  sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+    libffi-dev liblzma-dev git
+
+  echo "⬇️ Installing pyenv via the official installer..."
+  curl -fsSL https://pyenv.run | bash
+fi
+
+# Detect current shell (same approach as alias/install_aliases.sh)
+CURRENT_SHELL=$(basename "$SHELL")
+if [ -z "$CURRENT_SHELL" ]; then
+  CURRENT_SHELL=$(ps -p $$ -o comm=)
+fi
+if [[ "$CURRENT_SHELL" == "bash" ]]; then
+  PARENT_SHELL=$(ps -o comm= -p $PPID)
+  if [[ "$PARENT_SHELL" == "zsh" ]]; then
+    CURRENT_SHELL="zsh"
+  fi
+fi
+
+if [[ "$CURRENT_SHELL" == "zsh" ]]; then
+  RC_FILE="$HOME/.zshrc"
+else
+  RC_FILE="$HOME/.bashrc"
+fi
+
+if [ ! -f "$RC_FILE" ]; then
+  touch "$RC_FILE"
+fi
+
+echo "⚙️ Configuring pyenv in $RC_FILE..."
+
+if ! grep -q "PYENV_ROOT" "$RC_FILE"; then
+  {
+    echo ''
+    echo '# pyenv'
+    echo 'export PYENV_ROOT="$HOME/.pyenv"'
+    echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+    echo "eval \"\$(pyenv init - $CURRENT_SHELL)\""
+  } >> "$RC_FILE"
+  echo "✅ Added pyenv initialization to $RC_FILE"
+else
+  echo "ℹ️ pyenv initialization already present in $RC_FILE"
+fi
+
+echo "🎉 pyenv installed successfully!"
+echo "💡 Restart your shell or run: source $RC_FILE"
+echo "💡 Then install a Python version with: pyenv install 3.12.4 && pyenv global 3.12.4"


### PR DESCRIPTION
Adds tools/pyenv.sh to manage multiple Python versions:
- installs pyenv's build dependencies, then pyenv itself via the official https://pyenv.run installer (idempotent — skips both if $HOME/.pyenv already exists)
- detects the shell the same way install_aliases.sh/persist_env.sh do, and appends the pyenv init block to the matching rc file (.bashrc or .zshrc), only if it isn't already there

Wired into make (make pyenv), install.sh's menu (auto-discovered from tools/), and documented in the README.