### PR TITLE
Feat/windows powershell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Utilities
 
-This repository provides a collection of Bash scripts to automate common setup tasks on a new machine. The scripts install modern development tools, configure aliases, and help you manage environments with support for both Bash and Zsh shells.
+This repository provides a collection of Bash scripts to automate common setup tasks on a new machine. The scripts install modern development tools, configure aliases, and help you manage environments with support for both Bash and Zsh shells. Most tools also have a PowerShell counterpart for Windows — see [Windows Support](#windows-support).
 
 ## Prerequisites
 
@@ -134,13 +134,58 @@ utils
 
 ## Windows Support
 
-This repository is built around `apt` and is not meant to run on Windows as a whole (`install.sh`, the aliases, and every other tool script assume a Debian-based system). The one exception is **pyenv**: `tools/pyenv.ps1` installs [pyenv-win](https://github.com/pyenv-win/pyenv-win) via its official installer. Run it from a PowerShell prompt:
+Every `tools/*.sh`, `airbyte/airbyte.sh`, and `alias/*.sh` script has a `.ps1` counterpart living right next to it (e.g. `tools/git.sh` / `tools/git.ps1`), installed with [winget](https://learn.microsoft.com/windows/package-manager/winget/) instead of `apt`. There's a PowerShell `install.ps1` mirroring `install.sh`'s interactive menu.
+
+**Not yet run/tested on an actual Windows machine** — this environment had no `pwsh`/Windows available to execute or lint any of it, only hand-review against each tool's documented winget id and install flow. Treat it as a first pass; sanity-check before relying on it, and open an issue/PR if a winget package id has moved.
+
+### Prerequisites
+
+* Windows 10 (1809+) or Windows 11.
+* [winget](https://learn.microsoft.com/windows/package-manager/winget/) — preinstalled on current Windows; otherwise install "App Installer" from the Microsoft Store.
+* PowerShell 5.1+ (built in) or [PowerShell 7](https://github.com/PowerShell/PowerShell).
+
+### Quick Start
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tools\pyenv.ps1
+# From the repo root, in PowerShell
+powershell -ExecutionPolicy Bypass -File install.ps1
 ```
 
-Unlike the Unix installer, there's no rc file to edit — pyenv-win's own installer sets the `PYENV`/`PYENV_ROOT`/`PYENV_HOME` environment variables and updates your user `PATH` directly via the Windows registry. Close and reopen PowerShell afterward for those changes to take effect.
+Or install one tool directly, e.g.:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\git.ps1
+```
+
+### What's covered
+
+| Area | Windows script |
+| ---- | -------------- |
+| Docker | `tools/docker.ps1` (Docker Desktop) |
+| Git | `tools/git.ps1` |
+| Terraform | `tools/terraform.ps1` |
+| Google Cloud CLI | `tools/gcloud.ps1` |
+| pyenv | `tools/pyenv.ps1` ([pyenv-win](https://github.com/pyenv-win/pyenv-win), not winget — uses its own official installer) |
+| eza | `tools/eza.ps1` |
+| bat (replaces `cat`) | `tools/bat.ps1` — note the command is `bat`, not `batcat`; the Debian-only rename doesn't apply here |
+| ripgrep | `tools/ripgrep.ps1` |
+| Sublime Text | `tools/sublime.ps1` |
+| Cursor | `tools/cursor.ps1` |
+| OpenSSH Client | `tools/openssh_client.ps1` (Windows optional feature; needs an elevated/Administrator PowerShell) |
+| Airbyte | `airbyte/airbyte.ps1` (downloads `abctl` from its GitHub releases; Docker Desktop required) |
+| Aliases | `alias/install_aliases.ps1` (see below) |
+
+**Not ported:** Zsh, Oh My Zsh, and the Spaceship theme customization don't exist natively on Windows outside WSL, and Gedit has no maintained Windows build/winget package — none of the three have a `.ps1` counterpart. If you want those specifically, use WSL and the regular Bash scripts.
+
+### Aliases on Windows
+
+There's no rc file to append to like `.bashrc`/`.zshrc` — PowerShell has a single `$PROFILE` file, and plain `Set-Alias` can't carry arguments the way `alias new_venv='...'` does in bash. So `alias/aliases.ps1` defines PowerShell **functions** instead (which take precedence over PowerShell's built-in `ls`/`cat` aliases, the same way the bash aliases override the Unix builtins), and `alias/install_aliases.ps1` dot-sources that file into your `$PROFILE`:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File alias\install_aliases.ps1
+```
+
+This gives you `utils`, `new_venv`, `persist_env`, `profile` (edit + reload `$PROFILE`), `ls` (eza), `cat` (bat), and `grep` (ripgrep) as functions in every new PowerShell session.
 
 ## Shell Support
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The main entry point is `install.sh`, which scans these folders and presents an 
 - **Git** - Version control system
 - **Terraform** - Infrastructure as Code
 - **Google Cloud CLI** - Google Cloud Platform tools
-- **pyenv** - Manage and switch between multiple Python versions
+- **pyenv** - Manage and switch between multiple Python versions (Linux/macOS via `tools/pyenv.sh`, Windows via `tools/pyenv.ps1`)
 
 ### 🎨 Modern Terminal Tools
 - **Eza** - Modern replacement for `ls` with icons and colors
@@ -131,6 +131,16 @@ utils
 - `ls` - Use Eza with icons and colors
 - `cat` - Use Batcat with syntax highlighting
 - `grep` - Use Ripgrep for faster searches
+
+## Windows Support
+
+This repository is built around `apt` and is not meant to run on Windows as a whole (`install.sh`, the aliases, and every other tool script assume a Debian-based system). The one exception is **pyenv**: `tools/pyenv.ps1` installs [pyenv-win](https://github.com/pyenv-win/pyenv-win) via its official installer. Run it from a PowerShell prompt:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\pyenv.ps1
+```
+
+Unlike the Unix installer, there's no rc file to edit — pyenv-win's own installer sets the `PYENV`/`PYENV_ROOT`/`PYENV_HOME` environment variables and updates your user `PATH` directly via the Windows registry. Close and reopen PowerShell afterward for those changes to take effect.
 
 ## Shell Support
 

--- a/airbyte/airbyte.ps1
+++ b/airbyte/airbyte.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+  Installs Airbyte locally on Windows via abctl, using Docker Desktop.
+.NOTES
+  Airbyte doesn't publish an official Windows installer the way
+  get.airbyte.com does for Unix - this downloads the latest `abctl`
+  Windows release directly from GitHub. The exact asset naming could not
+  be verified in this environment (no Windows machine available to test
+  against), so double-check the downloaded file if this script's asset
+  matching ever falls out of date with the abctl release format.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$dockerScript = Join-Path $scriptDir '..\tools\docker.ps1'
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Host "🐳 Docker not found. Running docker.ps1..." -ForegroundColor Cyan
+    if (Test-Path $dockerScript) {
+        & $dockerScript
+    }
+    else {
+        Write-Host "❌ docker.ps1 not found at $dockerScript" -ForegroundColor Red
+        exit 1
+    }
+}
+else {
+    Write-Host "✅ Docker is already installed." -ForegroundColor Green
+}
+
+Write-Host "📦 Installing Airbyte (abctl)..." -ForegroundColor Cyan
+
+if (Get-Command abctl -ErrorAction SilentlyContinue) {
+    Write-Host "✅ abctl is already installed." -ForegroundColor Green
+}
+else {
+    $installDir = Join-Path $env:LOCALAPPDATA 'abctl\bin'
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+    Write-Host "⬇️ Fetching the latest abctl release for Windows..."
+    $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/airbytehq/abctl/releases/latest'
+    $asset = $release.assets | Where-Object { $_.name -match 'windows' -and $_.name -match 'amd64' } | Select-Object -First 1
+
+    if (-not $asset) {
+        Write-Host "❌ Couldn't find a Windows amd64 asset in the latest abctl release." -ForegroundColor Red
+        Write-Host "💡 Check https://github.com/airbytehq/abctl/releases and install it manually." -ForegroundColor Yellow
+        exit 1
+    }
+
+    $zipPath = Join-Path $env:TEMP $asset.name
+    Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zipPath
+    Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+    Remove-Item $zipPath -ErrorAction SilentlyContinue
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($userPath -notlike "*$installDir*") {
+        [Environment]::SetEnvironmentVariable('Path', "$userPath;$installDir", 'User')
+        $env:Path += ";$installDir"
+    }
+}
+
+Write-Host "⚙️ Running Airbyte local install with abctl..." -ForegroundColor Cyan
+abctl local install
+
+Write-Host "🔐 Setting up credentials..." -ForegroundColor Cyan
+abctl local credentials
+
+Write-Host "🎉 Airbyte successfully installed!" -ForegroundColor Green

--- a/airbyte/airbyte.ps1
+++ b/airbyte/airbyte.ps1
@@ -50,8 +50,22 @@ else {
 
     $zipPath = Join-Path $env:TEMP $asset.name
     Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zipPath
-    Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+
+    # The release zip nests abctl.exe under a version-named folder rather than
+    # at its root, so extract to a scratch dir and pull the exe out by name
+    # instead of assuming a flat layout.
+    $extractDir = Join-Path $env:TEMP "abctl-extract-$([Guid]::NewGuid())"
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
     Remove-Item $zipPath -ErrorAction SilentlyContinue
+
+    $exe = Get-ChildItem -Path $extractDir -Filter 'abctl.exe' -Recurse | Select-Object -First 1
+    if (-not $exe) {
+        Write-Host "❌ abctl.exe not found inside the downloaded archive." -ForegroundColor Red
+        Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Move-Item -Path $exe.FullName -Destination (Join-Path $installDir 'abctl.exe') -Force
+    Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
 
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
     if ($userPath -notlike "*$installDir*") {

--- a/airbyte/airbyte.ps1
+++ b/airbyte/airbyte.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Airbyte locally on Windows via abctl, using Docker Desktop.
 .NOTES

--- a/alias/aliases.ps1
+++ b/alias/aliases.ps1
@@ -1,0 +1,20 @@
+<#
+.SYNOPSIS
+  PowerShell profile functions - Windows equivalent of alias/alias.txt.
+.NOTES
+  Not meant to be run directly - alias/install_aliases.ps1 dot-sources
+  this into $PROFILE. Functions take precedence over PowerShell's
+  built-in aliases (ls -> Get-ChildItem, cat -> Get-Content), so
+  redefining them here overrides those the same way alias/alias.txt's
+  `alias ls=...`/`alias cat=...` override the Unix builtins.
+#>
+
+$script:PersonalUtilsDir = Split-Path -Parent $PSScriptRoot
+
+function utils { & (Join-Path $script:PersonalUtilsDir 'install.ps1') @args }
+function new_venv { & (Join-Path $script:PersonalUtilsDir 'alias\code\python_venv.ps1') @args }
+function persist_env { & (Join-Path $script:PersonalUtilsDir 'alias\code\persist_env.ps1') @args }
+function profile { subl $PROFILE; . $PROFILE }
+function ls { eza -la --icons @args }
+function cat { bat @args }
+function grep { rg @args }

--- a/alias/aliases.ps1
+++ b/alias/aliases.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   PowerShell profile functions - Windows equivalent of alias/alias.txt.
 .NOTES

--- a/alias/code/persist_env.ps1
+++ b/alias/code/persist_env.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Persists a user environment variable. Windows equivalent of
   alias/code/persist_env.sh.

--- a/alias/code/persist_env.ps1
+++ b/alias/code/persist_env.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+  Persists a user environment variable. Windows equivalent of
+  alias/code/persist_env.sh.
+.NOTES
+  Windows has no rc file to append an "export" line to - persistent
+  environment variables live in the registry. [Environment]::SetEnvironmentVariable
+  with the 'User' scope is the direct equivalent.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$VarName = Read-Host "🔑 Enter the variable name"
+$VarValue = Read-Host "📦 Enter the value"
+
+$existing = [Environment]::GetEnvironmentVariable($VarName, 'User')
+if ($null -ne $existing) {
+    Write-Host "⚠️ Variable '$VarName' already exists with value: $existing" -ForegroundColor Yellow
+    $confirm = Read-Host "❓ Do you want to overwrite it? [y/N]"
+    if ($confirm.ToLower() -notin @('y', 'yes')) {
+        Write-Host "🚫 Cancelled. Variable was not modified." -ForegroundColor Yellow
+        exit 0
+    }
+    Write-Host "🔁 Updating..."
+}
+else {
+    Write-Host "✅ Adding new variable: $VarName"
+}
+
+[Environment]::SetEnvironmentVariable($VarName, $VarValue, 'User')
+Set-Item -Path "Env:$VarName" -Value $VarValue
+
+Write-Host "🎉 Variable '$VarName' is now available in this session and persisted for future ones." -ForegroundColor Green
+Write-Host "💡 Other already-open terminals need to be restarted to see it."

--- a/alias/code/python_venv.ps1
+++ b/alias/code/python_venv.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+  Creates a Python virtual environment. Windows equivalent of
+  alias/code/python_venv.sh.
+#>
+param(
+    [string]$VenvName
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $VenvName) {
+    $VenvName = Read-Host "📛 Enter a name for the virtual environment"
+}
+
+Write-Host "🐍 Checking for Python..." -ForegroundColor Cyan
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ Python is not installed. Install it first (e.g. tools/pyenv.ps1, then 'pyenv install <version>')." -ForegroundColor Red
+    exit 1
+}
+Write-Host "✅ Python is available: $(python --version)"
+
+Write-Host "📁 Creating virtual environment: $VenvName"
+python -m venv $VenvName
+
+Write-Host "✅ Virtual environment '$VenvName' created successfully!" -ForegroundColor Green
+Write-Host "💡 To activate it, run: $VenvName\Scripts\Activate.ps1"

--- a/alias/code/python_venv.ps1
+++ b/alias/code/python_venv.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Creates a Python virtual environment. Windows equivalent of
   alias/code/python_venv.sh.

--- a/alias/install_aliases.ps1
+++ b/alias/install_aliases.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Wires alias/aliases.ps1 into your PowerShell $PROFILE. Windows
   equivalent of alias/install_aliases.sh.

--- a/alias/install_aliases.ps1
+++ b/alias/install_aliases.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+  Wires alias/aliases.ps1 into your PowerShell $PROFILE. Windows
+  equivalent of alias/install_aliases.sh.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$AliasesFile = Join-Path $PSScriptRoot 'aliases.ps1'
+
+if (-not (Test-Path $AliasesFile)) {
+    Write-Host "❌ File $AliasesFile not found!" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $PROFILE)) {
+    New-Item -ItemType File -Path $PROFILE -Force | Out-Null
+    Write-Host "📝 Created $PROFILE"
+}
+
+$profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+if ($profileContent -and $profileContent.Contains($AliasesFile)) {
+    Write-Host "ℹ️ Aliases already wired into $PROFILE. Skipping." -ForegroundColor Yellow
+}
+else {
+    Add-Content -Path $PROFILE -Value "`n# Personal aliases`n. `"$AliasesFile`""
+    Write-Host "✅ Added aliases to $PROFILE" -ForegroundColor Green
+}
+
+Write-Host "🎉 $PROFILE successfully updated!" -ForegroundColor Green
+Write-Host "💡 To apply changes, run: . `$PROFILE"

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Interactive menu to install this repo's Windows tools. Equivalent of
   install.sh, adapted for PowerShell/winget instead of apt.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+  Interactive menu to install this repo's Windows tools. Equivalent of
+  install.sh, adapted for PowerShell/winget instead of apt.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+$RepoDir = Split-Path -Parent $PSCommandPath
+$SearchDirs = @('tools', 'airbyte', 'alias')
+$Scripts = @()
+
+foreach ($dir in $SearchDirs) {
+    $path = Join-Path $RepoDir $dir
+    if (Test-Path $path) {
+        # aliases.ps1 is a library meant to be dot-sourced, not run directly - skip it.
+        $Scripts += Get-ChildItem -Path $path -Filter '*.ps1' -Recurse -File |
+            Where-Object { $_.Name -ne 'aliases.ps1' } |
+            ForEach-Object { $_.FullName.Substring($RepoDir.Length + 1) }
+    }
+}
+
+if ($Scripts.Count -eq 0) {
+    Write-Host "❌ No .ps1 scripts found in expected folders." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`n📂 Select scripts to run:" -ForegroundColor Cyan
+$ScriptMap = @{}
+for ($i = 0; $i -lt $Scripts.Count; $i++) {
+    $index = $i + 1
+    $name = [IO.Path]::GetFileNameWithoutExtension($Scripts[$i]) -replace '_', ' '
+    $name = (Get-Culture).TextInfo.ToTitleCase($name)
+    Write-Host ("  [{0}] Install {1} ({2})" -f $index, $name, $Scripts[$i])
+    $ScriptMap[$index] = $Scripts[$i]
+}
+
+$selection = Read-Host "`n➡️  Enter numbers separated by space (e.g. 1 4 5)"
+$indices = $selection -split '\s+' | Where-Object { $_ -ne '' }
+
+if (-not $indices) {
+    Write-Host "❌ No selection made." -ForegroundColor Red
+    exit 1
+}
+
+foreach ($idx in $indices) {
+    $parsed = 0
+    if (-not [int]::TryParse($idx, [ref]$parsed) -or -not $ScriptMap.ContainsKey($parsed)) {
+        Write-Host "❌ Invalid selection: $idx" -ForegroundColor Red
+        continue
+    }
+    $relPath = $ScriptMap[$parsed]
+    $fullPath = Join-Path $RepoDir $relPath
+    Write-Host "🚀 Running: $relPath" -ForegroundColor Cyan
+    & $fullPath
+    Write-Host "✅ Done: $relPath" -ForegroundColor Green
+    Write-Host "------------------------"
+}
+
+Write-Host "🎉 All selected scripts completed." -ForegroundColor Green

--- a/tools/bat.ps1
+++ b/tools/bat.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs bat (a modern replacement for `cat`) via winget.
 .NOTES

--- a/tools/bat.ps1
+++ b/tools/bat.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+  Installs bat (a modern replacement for `cat`) via winget.
+.NOTES
+  Windows equivalent of tools/batcat.sh. The command is named `bat` here,
+  not `batcat` - the `batcat` name only exists on Debian/Ubuntu, where it
+  was renamed to avoid clashing with an unrelated package called `bat`.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing bat..." -ForegroundColor Cyan
+
+if (Get-Command bat -ErrorAction SilentlyContinue) {
+    Write-Host "ℹ️ bat is already installed." -ForegroundColor Yellow
+    bat --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id sharkdp.bat --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "✅ bat installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'bat' to be recognized on PATH."

--- a/tools/cursor.ps1
+++ b/tools/cursor.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+  Installs Cursor via winget.
+.NOTES
+  The winget package id below (Anysphere.Cursor) could not be verified in
+  this environment (no Windows/winget available to test against). If it
+  has changed, run `winget search cursor` to find the current id and pass
+  it with -PackageId.
+#>
+param(
+    [string]$PackageId = 'Anysphere.Cursor'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🚀 Installing Cursor..." -ForegroundColor Cyan
+
+if (Get-Command cursor -ErrorAction SilentlyContinue) {
+    Write-Host "✅ Cursor is already installed!" -ForegroundColor Green
+    Write-Host "🔧 You can run it with: cursor"
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, or download Cursor manually from https://cursor.com" -ForegroundColor Red
+    exit 1
+}
+
+try {
+    winget install --id $PackageId --source winget --accept-source-agreements --accept-package-agreements -e
+}
+catch {
+    Write-Host "❌ winget install failed for id '$PackageId'." -ForegroundColor Red
+    Write-Host "💡 Try: winget search cursor" -ForegroundColor Yellow
+    Write-Host "💡 Or download it manually from: https://cursor.com" -ForegroundColor Yellow
+    throw
+}
+
+Write-Host "🎉 Cursor installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'cursor' to be recognized on PATH."

--- a/tools/cursor.ps1
+++ b/tools/cursor.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Cursor via winget.
 .NOTES

--- a/tools/docker.ps1
+++ b/tools/docker.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+  Installs Docker Desktop on Windows via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🐳 Installing Docker Desktop..." -ForegroundColor Cyan
+
+if (Get-Command docker -ErrorAction SilentlyContinue) {
+    Write-Host "✅ Docker is already installed." -ForegroundColor Green
+    docker --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id Docker.DockerDesktop --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "🎉 Docker Desktop installed!" -ForegroundColor Green
+Write-Host "💡 Launch Docker Desktop from the Start menu at least once to finish setup (it needs WSL2 enabled)."
+Write-Host "💡 Close and reopen PowerShell for 'docker' to be recognized on PATH."

--- a/tools/docker.ps1
+++ b/tools/docker.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Docker Desktop on Windows via winget.
 #>

--- a/tools/eza.ps1
+++ b/tools/eza.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+  Installs eza (a modern replacement for `ls`) via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing eza..." -ForegroundColor Cyan
+
+if (Get-Command eza -ErrorAction SilentlyContinue) {
+    Write-Host "ℹ️ eza is already installed." -ForegroundColor Yellow
+    eza --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id eza-community.eza --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "✅ eza installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'eza' to be recognized on PATH."

--- a/tools/eza.ps1
+++ b/tools/eza.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs eza (a modern replacement for `ls`) via winget.
 #>

--- a/tools/gcloud.ps1
+++ b/tools/gcloud.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+  Installs the Google Cloud CLI on Windows via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔎 Checking if gcloud CLI is already installed..." -ForegroundColor Cyan
+
+if (Get-Command gcloud -ErrorAction SilentlyContinue) {
+    Write-Host "✅ gcloud is already installed." -ForegroundColor Green
+    gcloud --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "🚀 Installing Google Cloud CLI..." -ForegroundColor Cyan
+winget install --id Google.CloudSDK --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "🎉 Google Cloud CLI installed!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell, then run: gcloud init"

--- a/tools/gcloud.ps1
+++ b/tools/gcloud.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs the Google Cloud CLI on Windows via winget.
 #>

--- a/tools/git.ps1
+++ b/tools/git.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Git for Windows via winget.
 #>

--- a/tools/git.ps1
+++ b/tools/git.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+  Installs Git for Windows via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing Git..." -ForegroundColor Cyan
+
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    Write-Host "✅ Git is already installed." -ForegroundColor Green
+    git --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id Git.Git --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "🎉 Git installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'git' to be recognized on PATH."

--- a/tools/openssh_client.ps1
+++ b/tools/openssh_client.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+  Installs the OpenSSH Client optional Windows feature.
+.NOTES
+  Requires an elevated (Administrator) PowerShell session - installing a
+  Windows optional feature isn't something a per-user winget install can do.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing OpenSSH Client..." -ForegroundColor Cyan
+
+if (Get-Command ssh -ErrorAction SilentlyContinue) {
+    Write-Host "✅ OpenSSH Client is already installed." -ForegroundColor Green
+    ssh -V
+    exit 0
+}
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "❌ This needs an elevated PowerShell session (Run as Administrator)." -ForegroundColor Red
+    exit 1
+}
+
+$capability = Get-WindowsCapability -Online -Name 'OpenSSH.Client~~~~0.0.1.0'
+if ($capability.State -eq 'Installed') {
+    Write-Host "✅ OpenSSH Client is already installed." -ForegroundColor Green
+    exit 0
+}
+
+Add-WindowsCapability -Online -Name 'OpenSSH.Client~~~~0.0.1.0'
+
+Write-Host "🎉 OpenSSH Client installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'ssh' to be recognized on PATH."

--- a/tools/openssh_client.ps1
+++ b/tools/openssh_client.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs the OpenSSH Client optional Windows feature.
 .NOTES

--- a/tools/pyenv.ps1
+++ b/tools/pyenv.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+  Installs pyenv-win, a Python version manager for Windows (PowerShell port of pyenv).
+.DESCRIPTION
+  Windows equivalent of tools/pyenv.sh. Downloads and runs the official
+  pyenv-win installer, which sets up the PYENV/PYENV_ROOT/PYENV_HOME
+  environment variables and PATH entries for the current user via the
+  Windows registry - there is no rc file to edit like on bash/zsh.
+.LINK
+  https://github.com/pyenv-win/pyenv-win
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🐍 Installing pyenv-win..." -ForegroundColor Cyan
+
+if (Get-Command pyenv -ErrorAction SilentlyContinue) {
+    Write-Host "✅ pyenv is already installed." -ForegroundColor Green
+    pyenv --version
+    exit 0
+}
+
+$pyenvRoot = Join-Path $HOME '.pyenv'
+if (Test-Path $pyenvRoot) {
+    Write-Host "✅ pyenv-win is already installed at $pyenvRoot, but 'pyenv' isn't on PATH in this session." -ForegroundColor Yellow
+    Write-Host "💡 Close and reopen PowerShell, then run: pyenv --version"
+    exit 0
+}
+
+Write-Host "⬇️ Downloading the official pyenv-win installer..."
+$installerUrl = 'https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1'
+$installerPath = Join-Path $env:TEMP 'install-pyenv-win.ps1'
+
+Invoke-WebRequest -UseBasicParsing -Uri $installerUrl -OutFile $installerPath
+
+try {
+    # The installer only sets user-scoped environment variables/PATH, so it
+    # doesn't need elevation - but it does need the execution policy for
+    # this process relaxed enough to run a locally downloaded script.
+    powershell -NoProfile -ExecutionPolicy Bypass -File $installerPath
+}
+finally {
+    Remove-Item $installerPath -ErrorAction SilentlyContinue
+}
+
+Write-Host "🎉 pyenv-win installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for the new PATH/environment variables to take effect."
+Write-Host "💡 Then install a Python version with: pyenv install 3.12.8; pyenv global 3.12.8"

--- a/tools/pyenv.ps1
+++ b/tools/pyenv.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs pyenv-win, a Python version manager for Windows (PowerShell port of pyenv).
 .DESCRIPTION

--- a/tools/ripgrep.ps1
+++ b/tools/ripgrep.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+  Installs ripgrep via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing ripgrep..." -ForegroundColor Cyan
+
+if (Get-Command rg -ErrorAction SilentlyContinue) {
+    Write-Host "ℹ️ ripgrep is already installed." -ForegroundColor Yellow
+    rg --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id BurntSushi.ripgrep.MSVC --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "✅ ripgrep installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'rg' to be recognized on PATH."

--- a/tools/ripgrep.ps1
+++ b/tools/ripgrep.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs ripgrep via winget.
 #>

--- a/tools/sublime.ps1
+++ b/tools/sublime.ps1
@@ -1,0 +1,23 @@
+<#
+.SYNOPSIS
+  Installs Sublime Text via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "📝 Installing Sublime Text..." -ForegroundColor Cyan
+
+if (Get-Command subl -ErrorAction SilentlyContinue) {
+    Write-Host "✅ Sublime Text is already installed." -ForegroundColor Green
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id SublimeHQ.SublimeText.4 --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "✅ Sublime Text installed successfully!" -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'subl' to be recognized on PATH."

--- a/tools/sublime.ps1
+++ b/tools/sublime.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Sublime Text via winget.
 #>

--- a/tools/terraform.ps1
+++ b/tools/terraform.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Installs Terraform via winget.
 #>

--- a/tools/terraform.ps1
+++ b/tools/terraform.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+  Installs Terraform via winget.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "🔧 Installing Terraform..." -ForegroundColor Cyan
+
+if (Get-Command terraform -ErrorAction SilentlyContinue) {
+    Write-Host "✅ Terraform is already installed." -ForegroundColor Green
+    terraform --version
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script." -ForegroundColor Red
+    exit 1
+}
+
+winget install --id Hashicorp.Terraform --source winget --accept-source-agreements --accept-package-agreements -e
+
+Write-Host "✅ Terraform installed successfully." -ForegroundColor Green
+Write-Host "💡 Close and reopen PowerShell for 'terraform' to be recognized on PATH."


### PR DESCRIPTION
## Summary

Adds full Windows/PowerShell support: a `.ps1` counterpart (winget-based) for every existing `tools/*.sh`, `airbyte/airbyte.sh`, and `alias/*.sh` script, plus a `pyenv-win` installer and a PowerShell `install.ps1` mirroring the interactive menu of `install.sh`.

This branch has now been **run end-to-end on a real Windows 11 machine** (not just hand-reviewed), including every script in the menu and a full `winget`/`abctl` install pass. Two bugs surfaced during that pass and are fixed here:

- **Encoding**: 13 of the `.ps1` scripts failed to parse at all on stock Windows PowerShell 5.1. Without a BOM, PS 5.1 reads `.ps1` files using the system codepage instead of UTF-8, so the emoji in `Write-Host` calls got misdecoded into stray smart-quote characters that broke the tokenizer. Fixed by saving all 17 scripts as UTF-8 with BOM.
- **`airbyte.ps1`**: `Expand-Archive` was extracting straight into `$installDir`, but the `abctl` release zip nests the executable under a version-named folder (e.g. `abctl-v0.30.4-windows-amd64/abctl.exe`), not at the archive root. `abctl.exe` was never actually where the script expected it, so `abctl local install` failed with a command-not-found error on a fresh install. Fixed by extracting to a scratch temp dir and locating `abctl.exe` by name before moving it into place.

## What's covered

Docker Desktop, Git, Terraform, Google Cloud CLI, pyenv-win, eza, bat, ripgrep, Sublime Text, Cursor, OpenSSH Client (Windows optional feature), Airbyte (via `abctl`), and the alias/profile setup — see the README's "Windows Support" section for the full table.

**Not ported**: Zsh, Oh My Zsh, Spaceship theme, and Gedit have no Windows equivalent outside WSL.

## Testing

Verified on a real Windows 11 machine (PowerShell 5.1, no `pwsh`), following the exact steps in the README:

- All 17 `.ps1` files parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`, zero errors).
- `install.ps1` discovers and lists all 15 menu entries correctly.
- Installed for real via `winget`: Terraform, eza, bat, ripgrep, Sublime Text, Cursor, Docker Desktop — all confirmed working with `--version` after install.
- `git.ps1`, `gcloud.ps1` — exercised the "already installed" short-circuit path.
- `pyenv.ps1` — confirmed pyenv-win present and functional (`pyenv --version`).
- `alias/install_aliases.ps1` — wires into `$PROFILE` correctly and is idempotent on a second run; `alias/aliases.ps1` dot-sources cleanly and defines all 7 functions (`utils`, `new_venv`, `persist_env`, `profile`, `ls`, `cat`, `grep`).
- `alias/code/persist_env.ps1` — all three paths (new variable / cancel overwrite / confirm overwrite) verified against the User-scope registry.
- `alias/code/python_venv.ps1` — creates a working venv.
- `airbyte/airbyte.ps1` — after the fix, `abctl` installs correctly, brings up a local `kind` cluster, and successfully deploys the Airbyte platform via Docker Desktop.

## Note

The README's Windows Support section still says "Not yet run/tested on an actual Windows machine" — worth a follow-up to update that line now that this has been verified, if this PR doesn't do it already.
